### PR TITLE
Upgrade deps to more recent versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 
 requires = [
     "six==1.15.0",
-    "PyYAML==5.4.1",
-    "psycopg2-binary==2.8.6"
+    "PyYAML==6.0.1",
+    "psycopg2-binary==2.9.9"
 ]
 
 


### PR DESCRIPTION
The dependencies are too old and cannot be installed with newer Python versions. I've verified locally that the migrations can be run successfully.